### PR TITLE
Bug fix: MDB_BAD_VALSIZE when saving words greater than the LMDB max key size

### DIFF
--- a/lmdb_embeddings/tests/test_embeddings_writer.py
+++ b/lmdb_embeddings/tests/test_embeddings_writer.py
@@ -93,3 +93,15 @@ class TestEmbeddingsWriter(LmdbEmbeddingsTest):
 
         with pytest.raises(exceptions.MissingWordError):
             reader.get_word_vector('unknown')
+
+    @LmdbEmbeddingsTest.make_temporary_folder
+    def test_word_too_long(self, folder_path):
+        """ Ensure we do not get an exception if
+        attempting to write a word longer than
+        LMDB's max key size,
+
+        :return void
+        """
+        LmdbEmbeddingsWriter([
+            ('a' * 1000, np.ndarray(10)),
+        ]).write(folder_path)


### PR DESCRIPTION
## Summary
Preventing `MDB_BAD_VALSIZE` errors when attempting to save the vector for a word longer than LMDB's maximum size.

## Entities
https://github.com/ThoughtRiver/lmdb-embeddings/pull/4