### PR TITLE
"ReadonlyError" permission error If user doesn't have a write permissions. user should able to set lock=False

### DIFF
--- a/lmdb_embeddings/reader.py
+++ b/lmdb_embeddings/reader.py
@@ -28,7 +28,7 @@ class LmdbEmbeddingsReader:
 
     def __init__(self, path, unserializer = PickleSerializer.unserialize, lock = True):
         """ Constructor.
-
+        lock = False if you have readonly access to db location else True
         :return void
         """
         self.unserializer = unserializer

--- a/lmdb_embeddings/reader.py
+++ b/lmdb_embeddings/reader.py
@@ -35,6 +35,7 @@ class LmdbEmbeddingsReader:
         self.environment = lmdb.open(
             path,
             readonly = True,
+            lock=True,
             max_readers = 2048,
             max_spare_txns = 2
         )

--- a/lmdb_embeddings/reader.py
+++ b/lmdb_embeddings/reader.py
@@ -26,7 +26,7 @@ from lmdb_embeddings.serializers import PickleSerializer
 
 class LmdbEmbeddingsReader:
 
-    def __init__(self, path, unserializer = PickleSerializer.unserialize):
+    def __init__(self, path, unserializer = PickleSerializer.unserialize, lock = True):
         """ Constructor.
 
         :return void
@@ -35,7 +35,7 @@ class LmdbEmbeddingsReader:
         self.environment = lmdb.open(
             path,
             readonly = True,
-            lock=True,
+            lock=lock,
             max_readers = 2048,
             max_spare_txns = 2
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+numpy==1.14.3
+setuptools==39.1.0
+msgpack_numpy==0.4.3.1
+pytest==3.5.1
+tqdm==4.25.0
+gensim==3.6.0
+lmdb==0.94
+msgpack_python==0.5.6


### PR DESCRIPTION
If the user doesn't have write permissions and lock (which is lmdb's parameter) is True then it gives "ReadonlyError" permission error.  To avoid this user must have exposed to parameter "lock" which user can set to False
	Example :  (path are encrypted for security purpose)
	ReadonlyError                             Traceback (most recent call last)
	<ipython-input-3-ffd24fe61474> in <module>()
	1 from lmdb_embeddings.reader import LmdbEmbeddingsReader
	2 from lmdb_embeddings.exceptions import MissingWordError
	----> 3 embeddings = LmdbEmbeddingsReader('/home/XXXXXX.XXXXXX/XXXXXX/XXXXXX/XXXXXX/')
	~/anaconda3/lib/python3.6/site-packages/lmdb_embeddings-0.0.1-py3.6.egg/lmdb_embeddings/reader.py in __init__(self, path, unserializer)
	38             readonly = True,
	39             max_readers = 2048,
	---> 40             max_spare_txns = 2
	41         )
	42 
	ReadonlyError: /home/XXXXXX.XXXXXX/XXXXXX/XXXX... (show balloon)