### PR TITLE
Bug fix: Changing lock to default to false on the LmdbReader

### DIFF
--- a/lmdb_embeddings/reader.py
+++ b/lmdb_embeddings/reader.py
@@ -26,7 +26,7 @@ from lmdb_embeddings.serializers import PickleSerializer
 
 class LmdbEmbeddingsReader:
 
-    def __init__(self, path, unserializer = PickleSerializer.unserialize):
+    def __init__(self, path, unserializer = PickleSerializer.unserialize, **kwargs):
         """ Constructor.
 
         :return void
@@ -36,7 +36,9 @@ class LmdbEmbeddingsReader:
             path,
             readonly = True,
             max_readers = 2048,
-            max_spare_txns = 2
+            max_spare_txns = 2,
+            lock = kwargs.pop('lock', False),
+            **kwargs
         )
 
     def get_word_vector(self, word):


### PR DESCRIPTION
## Summary
Changing the `LmdbReader` to default to `lock = false`. This should prevent the [ReadonlyError](https://github.com/ThoughtRiver/lmdb-embeddings/pull/7) and the [MDB_BAD_RSLOT issue](https://github.com/ThoughtRiver/lmdb-embeddings/issues/8).

Additionally, providing the ability to supply additional keyword arguments to the Lmdb environment.

## Entities
TP#8390
https://github.com/ThoughtRiver/lmdb-embeddings/issues/8
https://github.com/ThoughtRiver/lmdb-embeddings/pull/7